### PR TITLE
Fix Firestore 'ns binding aborted' error for workspace admins

### DIFF
--- a/src/contexts/TenantContext.js
+++ b/src/contexts/TenantContext.js
@@ -54,64 +54,82 @@ export function TenantProvider({ children }) {
       // If super admin, load all tenants
       if (isAdmin) {
         console.log('[TENANT DEBUG] User is super admin, loading all tenants');
-        const tenantsRef = collection(db, 'tenants');
-        const tenantsSnap = await getDocs(tenantsRef);
-        const allTenants = [];
+        try {
+          const tenantsRef = collection(db, 'tenants');
+          const tenantsSnap = await getDocs(tenantsRef);
+          const allTenants = [];
 
-        tenantsSnap.forEach((doc) => {
-          allTenants.push({ id: doc.id, ...doc.data() });
-        });
+          tenantsSnap.forEach((doc) => {
+            allTenants.push({ id: doc.id, ...doc.data() });
+          });
 
-        setAvailableTenants(allTenants);
+          setAvailableTenants(allTenants);
 
-        // Auto-select first tenant or last used
-        if (allTenants.length > 0) {
-          const lastTenantId = localStorage.getItem('lastTenantId');
-          const lastTenant = allTenants.find(t => t.id === lastTenantId);
-          console.log('[TENANT DEBUG] Super admin has', allTenants.length, 'tenants. Last tenant from localStorage:', lastTenantId);
-          console.log('[TENANT DEBUG] Auto-selecting:', lastTenant ? lastTenant.name : allTenants[0].name);
-          setCurrentTenant(lastTenant || allTenants[0]);
+          // Auto-select first tenant or last used
+          if (allTenants.length > 0) {
+            const lastTenantId = localStorage.getItem('lastTenantId');
+            const lastTenant = allTenants.find(t => t.id === lastTenantId);
+            console.log('[TENANT DEBUG] Super admin has', allTenants.length, 'tenants. Last tenant from localStorage:', lastTenantId);
+            console.log('[TENANT DEBUG] Auto-selecting:', lastTenant ? lastTenant.name : allTenants[0].name);
+            setCurrentTenant(lastTenant || allTenants[0]);
+          }
+        } catch (err) {
+          console.error('[TENANT ERROR] Failed to load tenants for super admin:', err);
+          if (err.code === 'failed-precondition' || err.message?.includes('ns binding')) {
+            setError('Database connection error. Please refresh the page.');
+          } else {
+            throw err;
+          }
         }
       } else {
         // Load tenants user is a member of
-        const membershipsRef = collection(db, 'tenant_members');
-        const q = query(
-          membershipsRef,
-          where('userEmail', '==', userEmail),
-          where('status', '==', 'active')
-        );
+        try {
+          const membershipsRef = collection(db, 'tenant_members');
+          const q = query(
+            membershipsRef,
+            where('userEmail', '==', userEmail),
+            where('status', '==', 'active')
+          );
 
-        const snapshot = await getDocs(q);
-        const tenantIds = new Set();
+          const snapshot = await getDocs(q);
+          const tenantIds = new Set();
 
-        snapshot.forEach((doc) => {
-          tenantIds.add(doc.data().tenantId);
-        });
+          snapshot.forEach((doc) => {
+            tenantIds.add(doc.data().tenantId);
+          });
 
-        // Fetch tenant details
-        const tenants = [];
-        for (const tenantId of tenantIds) {
-          const tenantDoc = await getDoc(doc(db, 'tenants', tenantId));
-          if (tenantDoc.exists()) {
-            tenants.push({ id: tenantDoc.id, ...tenantDoc.data() });
+          // Fetch tenant details
+          const tenants = [];
+          for (const tenantId of tenantIds) {
+            const tenantDoc = await getDoc(doc(db, 'tenants', tenantId));
+            if (tenantDoc.exists()) {
+              tenants.push({ id: tenantDoc.id, ...tenantDoc.data() });
+            }
           }
-        }
 
-        setAvailableTenants(tenants);
+          setAvailableTenants(tenants);
 
-        // Auto-select tenant
-        if (tenants.length === 1) {
-          console.log('[TENANT DEBUG] User has 1 tenant, auto-selecting:', tenants[0].name, tenants[0].id);
-          setCurrentTenant(tenants[0]);
-        } else if (tenants.length > 1) {
-          const lastTenantId = localStorage.getItem('lastTenantId');
-          const lastTenant = tenants.find(t => t.id === lastTenantId);
-          console.log('[TENANT DEBUG] User has', tenants.length, 'tenants. Last tenant from localStorage:', lastTenantId, 'Found:', !!lastTenant);
-          console.log('[TENANT DEBUG] Available tenants:', tenants.map(t => ({ name: t.name, id: t.id })));
-          setCurrentTenant(lastTenant || tenants[0]);
-        } else {
-          console.log('[TENANT DEBUG] User has no tenants');
-          setCurrentTenant(null);
+          // Auto-select tenant
+          if (tenants.length === 1) {
+            console.log('[TENANT DEBUG] User has 1 tenant, auto-selecting:', tenants[0].name, tenants[0].id);
+            setCurrentTenant(tenants[0]);
+          } else if (tenants.length > 1) {
+            const lastTenantId = localStorage.getItem('lastTenantId');
+            const lastTenant = tenants.find(t => t.id === lastTenantId);
+            console.log('[TENANT DEBUG] User has', tenants.length, 'tenants. Last tenant from localStorage:', lastTenantId, 'Found:', !!lastTenant);
+            console.log('[TENANT DEBUG] Available tenants:', tenants.map(t => ({ name: t.name, id: t.id })));
+            setCurrentTenant(lastTenant || tenants[0]);
+          } else {
+            console.log('[TENANT DEBUG] User has no tenants');
+            setCurrentTenant(null);
+          }
+        } catch (err) {
+          console.error('[TENANT ERROR] Failed to load tenants for user:', err);
+          if (err.code === 'failed-precondition' || err.message?.includes('ns binding')) {
+            setError('Database connection error. Please refresh the page.');
+          } else {
+            throw err;
+          }
         }
       }
     } catch (err) {
@@ -167,7 +185,11 @@ export function TenantProvider({ children }) {
           setIsWorkspaceAdmin(false);
         }
       } catch (err) {
-        console.error('Failed to check workspace admin status:', err);
+        console.error('[TENANT ERROR] Failed to check workspace admin status:', err);
+        if (err.code === 'failed-precondition' || err.message?.includes('ns binding')) {
+          console.error('Database connection error. Please refresh the page.');
+          setError('Database connection error. Please refresh the page.');
+        }
         setIsWorkspaceAdmin(false);
       }
     };


### PR DESCRIPTION
This commit addresses the Firestore initialization error that was specifically affecting workspace admins (not super admins) when accessing the admin portal.

Changes:
1. Firebase initialization (src/lib/firebase.js):
   - Added browser-only initialization check (typeof window !== 'undefined')
   - Implemented proper Firestore initialization with persistentLocalCache
   - Added persistentMultipleTabManager to prevent cross-tab conflicts
   - Added try-catch for initialization failures

2. Enhanced error handling in tenantUtils (src/lib/tenantUtils.js):
   - Added try-catch blocks to all Firestore operations
   - Specific detection for 'ns binding' and 'failed-precondition' errors
   - Improved error messages for better user feedback

3. Improved TenantContext error handling (src/contexts/TenantContext.js):
   - Added comprehensive error handling for all tenant loading operations
   - Specific handling for workspace admin status checks
   - Better error reporting for database connection issues

The root cause was improper Firestore initialization without cache settings, which caused 'ns binding aborted' errors when multiple Firestore operations were initiated simultaneously by workspace admins.