### PR TITLE
Fix Listen channel error with long polling and hot reload support

### DIFF
--- a/src/lib/firebase.js
+++ b/src/lib/firebase.js
@@ -1,7 +1,7 @@
 // src/lib/firebase.js
-import { initializeApp, getApps } from 'firebase/app';
+import { initializeApp, getApps, deleteApp } from 'firebase/app';
 import { getAuth, GoogleAuthProvider } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import { getFirestore, initializeFirestore, terminate } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -13,26 +13,90 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-// Initialize Firebase app - use default settings to avoid cache conflicts
-// The previous persistent/memory cache configurations were causing "ns binding aborted" errors
-let app;
-let db;
-let auth;
+// Use global variable to persist across hot reloads in development
+// This prevents multiple Firebase instances during Next.js hot module replacement
+const globalForFirebase = globalThis;
 
-// Only initialize in browser environment
-if (typeof window !== 'undefined') {
-  // Ensure single initialization
-  if (getApps().length === 0) {
-    app = initializeApp(firebaseConfig);
-  } else {
-    app = getApps()[0];
+if (!globalForFirebase._firebaseInitialized) {
+  globalForFirebase._firebaseApp = null;
+  globalForFirebase._firebaseDb = null;
+  globalForFirebase._firebaseAuth = null;
+  globalForFirebase._firebaseInitialized = false;
+}
+
+function initializeFirebaseApp() {
+  // Return existing instance if already initialized
+  if (globalForFirebase._firebaseInitialized && globalForFirebase._firebaseApp) {
+    return {
+      app: globalForFirebase._firebaseApp,
+      db: globalForFirebase._firebaseDb,
+      auth: globalForFirebase._firebaseAuth,
+    };
   }
 
-  // Use default Firestore settings - no custom cache configuration
-  // This prevents ns binding and Listen channel errors
-  db = getFirestore(app);
-  auth = getAuth(app);
+  // Only initialize in browser
+  if (typeof window === 'undefined') {
+    return { app: null, db: null, auth: null };
+  }
+
+  try {
+    // Get or create Firebase app
+    let app;
+    const existingApps = getApps();
+
+    if (existingApps.length > 0) {
+      app = existingApps[0];
+    } else {
+      app = initializeApp(firebaseConfig);
+    }
+
+    // Initialize Firestore with long polling to avoid WebChannel/Listen errors
+    // This forces the use of long polling instead of WebSocket connections
+    // which can fail in certain network/browser configurations
+    let db;
+    try {
+      // Try to initialize with long polling settings
+      // This will fail if already initialized, so we'll catch and use getFirestore
+      db = initializeFirestore(app, {
+        experimentalForceLongPolling: true,
+        experimentalAutoDetectLongPolling: true,
+      });
+    } catch (error) {
+      // If already initialized (e.g., hot reload), get the existing instance
+      console.log('Using existing Firestore instance');
+      db = getFirestore(app);
+    }
+
+    const auth = getAuth(app);
+
+    // Store in global to survive hot reloads
+    globalForFirebase._firebaseApp = app;
+    globalForFirebase._firebaseDb = db;
+    globalForFirebase._firebaseAuth = auth;
+    globalForFirebase._firebaseInitialized = true;
+
+    // Cleanup on hot module replacement
+    if (module.hot) {
+      module.hot.dispose(async () => {
+        try {
+          if (db) await terminate(db);
+          if (app) await deleteApp(app);
+        } catch (error) {
+          console.warn('Firebase cleanup warning:', error);
+        }
+        globalForFirebase._firebaseInitialized = false;
+      });
+    }
+
+    return { app, db, auth };
+  } catch (error) {
+    console.error('Firebase initialization error:', error);
+    throw error;
+  }
 }
+
+// Initialize once
+const { app, db, auth } = initializeFirebaseApp();
 
 export { auth, db };
 export const googleProvider = new GoogleAuthProvider();


### PR DESCRIPTION
Add comprehensive fixes for the persistent Firestore Listen channel error:

1. Force Long Polling:
   - Use experimentalForceLongPolling to avoid WebSocket/WebChannel
   - Add experimentalAutoDetectLongPolling as fallback
   - This prevents "Listen/channel" connection errors

2. Hot Module Replacement Support:
   - Use globalThis to persist Firebase instance across HMR
   - Add module.hot.dispose cleanup for development
   - Prevents multiple instances during Next.js hot reloads

3. Robust Singleton Pattern:
   - Check global state before initialization
   - Handle both initial and HMR scenarios
   - Graceful fallback if Firestore already initialized

The experimentalForceLongPolling setting forces Firestore to use XHR long polling instead of WebSocket connections, which resolves the WebChannel/Listen errors that were blocking admin portal access.